### PR TITLE
change encoding to UTF8 from ASCII

### DIFF
--- a/WxTCmd/Program.cs
+++ b/WxTCmd/Program.cs
@@ -274,7 +274,7 @@ namespace WxTCmd
                         var displayText = string.Empty;
                         var contentInfo = string.Empty;
 
-                        var payload = Encoding.ASCII.GetString(act.Payload);
+                        var payload = Encoding.UTF8.GetString(act.Payload);
 
                         if (payload.StartsWith("{"))
                         {


### PR DESCRIPTION
Hello,

I'm @kdogi's co-worker.
According to him, even after you corrected it (after this issue: https://github.com/EricZimmerman/WxTCmd/issues/1), the Japanese string of tsv to be output was garbled.

I found a place that is considered to be the cause, so I will send you this pull request (fixed this issue : https://github.com/EricZimmerman/WxTCmd/issues/2).

Regards,
nhnmomonga