### PR TITLE
SQLite Linux Support

### DIFF
--- a/.github/workflows/build_linux_sqlite_interop.yml
+++ b/.github/workflows/build_linux_sqlite_interop.yml
@@ -1,0 +1,30 @@
+name: Download and Compile SQLite Interop Assembly Linux
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Download SQLite source
+      run: wget https://system.data.sqlite.org/blobs/1.0.119.0/sqlite-netFx-full-source-1.0.119.0.zip
+
+    - name: Unzip SQLite source
+      run: unzip sqlite-netFx-full-source-1.0.119.0.zip
+
+    - name: Grant execute permissions
+      run: chmod +x Setup/compile-interop-assembly-release.sh
+
+    - name: Run compile script
+      run: Setup/compile-interop-assembly-release.sh
+
+    - name: Upload compiled library
+      uses: actions/upload-artifact@v4
+      with:
+        name: libSQLite.Interop.so
+        path: bin/2013/Release/bin/libSQLite.Interop.so

--- a/LINUX.md
+++ b/LINUX.md
@@ -1,0 +1,29 @@
+# Building WxTCmd on Linux
+
+Recent changes have allowed WxTCmd to run natively on Linux. This has been tested on Ubuntu 22.04 LTS and .NET 9
+
+In order to do this you will need to download .NET 9 SDK on Linux. I followed the instructions [here](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet9&pivots=os-linux-ubuntu-2404). 
+
+In the case of Ubuntu, you will need to install build-essential if you wish to compile the `libSQLite.Interop.so` yourself by doing sudo apt-get update and sudo apt install build-essential
+
+If you have issues with the bundled `libSQLite.Interop.so` the steps to build your own are as follows:
+Download the source code for the library by navigating [here](https://system.data.sqlite.org/index.html/doc/trunk/www/downloads.wiki) and downloading the one that says `sqlite-netFx-full-source-1.0.119.0.zip`
+
+Uncompress the zip file and issue the following commands in a Linux terminal:
+```
+cd LOCATIONOFSOURCE/Setup
+chmod +x compile-interop-assembly-release.sh
+./compile-interop-assembly-release.sh
+```
+Now, you will have a freshly built library file called libSQLite.Interop.so in the `LOCATIONOFSOURCE/bin/2013/Release/bin` folder.
+
+Download the WxTCmd source code if you haven't already [here](https://github.com/EricZimmerman/WxTCmd/archive/refs/heads/master.zip) and copy and replace the `libSQLite.Interop.so` file located in `WxTCmd/Dependencies/x64/libSQLite.Interop.so`
+
+To build the native Linux Binary, issue the following commands in a Linux terminal:
+```
+cd LOCATIONOFWXTCMDMASTERFOLDER - This will have WxTCmd.sln 
+dotnet publish -f net9.0 -r linux-x64
+```
+
+When this finishes, the resulting files will be located in `LOCATIONOFWXTCMDMASTERFOLDER/WxTCmd/bin/Release/net9.0/linux-x64/publish`
+All you need to do is copy these files to another folder and run it in terminal with `./WxTCmd`

--- a/WxTCmd/Program.cs
+++ b/WxTCmd/Program.cs
@@ -724,6 +724,21 @@ internal class Program
             "Processing complete in {TotalSeconds:N4} seconds",sw1.Elapsed.TotalSeconds);
         Console.WriteLine();
 
+#if NET6_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)){ 
+        if (File.Exists("libSQLite.Interop.so"))
+        {
+            try
+            {
+                File.Delete("libSQLite.Interop.so");
+            }
+            catch (Exception)
+            {
+                Log.Warning("Unable to delete {Sql}. Delete manually if needed","libSQLite.Interop.so");
+                Console.WriteLine();
+            }
+        }
+        } else {
         if (File.Exists("SQLite.Interop.dll"))
         {
             try
@@ -736,10 +751,43 @@ internal class Program
                 Console.WriteLine();
             }
         }
+        }
+#else
+        if (File.Exists("SQLite.Interop.dll"))
+        {
+            try
+            {
+                File.Delete("SQLite.Interop.dll");
+            }
+            catch (Exception)
+            {
+                Log.Warning("Unable to delete {Sql}. Delete manually if needed","SQLite.Interop.dll");
+                Console.WriteLine();
+            }
+        }
+#endif        
     }
 
     private static void DumpSqliteDll()
     {
+#if NET6_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)){
+        var sqllitefile = "libSQLite.Interop.so"; 
+
+        if (Environment.Is64BitProcess)
+        {
+            File.WriteAllBytes(sqllitefile, Resources.x64SQLite_Interop_linux);
+        }
+        else
+        {
+            //32 Bit Not Tested on Linux
+            //File.WriteAllBytes(sqllitefile, Resources.x86SQLite_Interop_linux);
+            Log.Warning("32 Bit Linux Not Supported! Exiting");
+            Console.WriteLine();
+            Environment.Exit(-1);
+        }
+        } else {
+
         var sqllitefile = "SQLite.Interop.dll";
 
         if (Environment.Is64BitProcess)
@@ -750,6 +798,19 @@ internal class Program
         {
             File.WriteAllBytes(sqllitefile, Resources.x86SQLite_Interop);
         }
+        }
+#else
+        var sqllitefile = "SQLite.Interop.dll";
+
+        if (Environment.Is64BitProcess)
+        {
+            File.WriteAllBytes(sqllitefile, Resources.x64SQLite_Interop);
+        }
+        else
+        {
+            File.WriteAllBytes(sqllitefile, Resources.x86SQLite_Interop);
+        }
+#endif        
     }
 
   

--- a/WxTCmd/Properties/Resources.Designer.cs
+++ b/WxTCmd/Properties/Resources.Designer.cs
@@ -88,5 +88,15 @@ namespace WxTCmd.Properties {
                 return ((byte[])(obj));
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] x64SQLite_Interop_linux {
+            get {
+                object obj = ResourceManager.GetObject("x64SQLite_Interop_linux", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
     }
 }

--- a/WxTCmd/Properties/Resources.resx
+++ b/WxTCmd/Properties/Resources.resx
@@ -127,4 +127,7 @@
   <data name="x86SQLite_Interop" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Dependencies\x86\SQLite.Interop.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="x64SQLite_Interop_linux" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Dependencies\x64\libSQLite.Interop.so;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>  
 </root>

--- a/WxTCmd/WxTCmd.csproj
+++ b/WxTCmd/WxTCmd.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Files\x64\SQLite.Interop.dll" />
+    <None Include="Files\x64\libSQLite.Interop.so" />
     <None Include="Files\\x86\SQLite.Interop.dll" />
     
     <Content Include="Calendar Money64.ico" />


### PR DESCRIPTION
Following [#83](https://github.com/EricZimmerman/SQLECmd/pull/83) and [#85](https://github.com/EricZimmerman/SQLECmd/pull/85) this implements the same for WxTCmd. As mentioned in the other pull requests I will need either @EricZimmerman or @AndrewRathbun to run this Github action once and upload the compiled libSQLite.Interop.so binary to the WxTCmd/Dependencies/x64 folder. The binary can be shared between both projects as the compiled libSQLite.Interop.so file should be identical across both. 