### PR TITLE
Regex userProfile Fix

### DIFF
--- a/WxTCmd/Program.cs
+++ b/WxTCmd/Program.cs
@@ -203,7 +203,7 @@ internal class Program
 
             
         try {
-            userProfile = Regex.Match(f, @"\\Users\\(.+?)\\", RegexOptions.IgnoreCase).Groups[1].Value;
+            userProfile = Regex.Match(f, @"(?:\\|/)Users(?:\\|/)([^\\\/]+)(?!.*(?:\\|/)Users(?:\\|/))", RegexOptions.IgnoreCase).Groups[1].Value;
 
             if (userProfile.Length > 0)
             {


### PR DESCRIPTION
This pull request modifies the regex for userProfile to fix two issues: 
- **Linux support**  
Original regex only looked for Windows-style backslashes (`\Users\`).  
New regex accepts both `\` and `/` as path separators, so it works on Linux instead of returning no user i.e. instead of `20250621124328_Activity.csv` it will now output correctly `20250621124328_ActualName_Activity.csv`

- **Capture the last user folder**  
Original regex grabbed the first `Users\<username>` it encountered.  
Updated regex uses a negative look-ahead to ensure it matches the last occurrence, so if the path contains multiple `Users` folders it will return the final one 

Paths like `/home/user/Desktop/Triage/C/Users/bob/AppData/Local/ConnectedDevicesPlatform/L.bob/ActivitiesCache.db` and  
  `C:\Users\bob\AppData\Local\ConnectedDevicesPlatform\L.bob\ActivitiesCache.db` both give the correct username `bob`.  

If the Path is `C:\Users\FirstUser\Desktop\Triage\Users\SecondUser\AppData\Local\ConnectedDevicesPlatform\L.seconduser\ActivitiesCache.db` It will use `SecondUser` instead of `FirstUser`