### PR TITLE
Fix error for -f

### DIFF
--- a/WxTCmd/Program.cs
+++ b/WxTCmd/Program.cs
@@ -178,9 +178,8 @@ internal class Program
         if (f.IsNullOrEmpty())
         {
             var aaa = new CustomHelpAction(new HelpAction());
-            aaa.Invoke(_rootCommand.Parse("--dl is required. Exiting"));
+            aaa.Invoke(_rootCommand.Parse("-f is required. Exiting"));
 
-            Log.Warning("-f is required. Exiting");
             Console.WriteLine();
             return;
         }


### PR DESCRIPTION
--dl does not exist for WxTCmd and if it was meant to be dt a default value was set anyway. This makes me believe it was a typo/ copy paste error rather than purposeful. Aligned it with the other error messages.